### PR TITLE
Fix graph data cleanup and return typing

### DIFF
--- a/src/GraphSerialiser.ts
+++ b/src/GraphSerialiser.ts
@@ -23,7 +23,7 @@ export class GraphSerialiser<NodeType extends GraphNode, LinkProps> {
         return { nodes, edges }
     }
 
-    deserialise(data: SerialisedGraph<NodeType, LinkProps>) {
+    deserialise(data: SerialisedGraph<NodeType, LinkProps>): Graph<NodeType, LinkProps> {
         const g = new Graph<NodeType, LinkProps>()
         const map = new Map(data.nodes.map(n => [n.id, n] as const))
         data.nodes.forEach(n => g.addNode(n))

--- a/src/GraphStore.ts
+++ b/src/GraphStore.ts
@@ -21,8 +21,14 @@ export class GraphStore<NodeType extends GraphNode, LinkProps> implements IGraph
         this.edges.delete(node.id);
         this.weights.delete(node.id);
         this.properties.delete(node.id);
-        for (const neighbours of this.edges.values()) {
-            neighbours.forEach(n => { if (n.id === node.id) neighbours.delete(n) })
+        for (const [srcId, neighbours] of this.edges.entries()) {
+            neighbours.forEach(n => {
+                if (n.id === node.id) {
+                    neighbours.delete(n)
+                    this.weights.get(srcId)?.delete(node.id)
+                    this.properties.get(srcId)?.delete(node.id)
+                }
+            })
         }
     }
 


### PR DESCRIPTION
## Summary
- clean up incoming edge data when removing a node
- type the return of `GraphSerialiser.deserialise`

## Testing
- `yarn test` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68404d7210f883219b8cfdcbceb5e240